### PR TITLE
fix/ Remove constructor in PUM (Closes #53)

### DIFF
--- a/src/main/java/se/kth/DD2480/PUM.java
+++ b/src/main/java/se/kth/DD2480/PUM.java
@@ -7,19 +7,5 @@ public class PUM
     public PUM(int n) {
         this.arr = new boolean[n][n];
     }
-    public PUM(int n, LCM lcm, CMV cmv){
-        this.arr = new boolean[n][n];
-        boolean[] cmvArray = cmv.verifyAllLics(0.0, null, 0, 0, 0, 0.0);
-        for(int i = 0; i < n; ++i){
-            for (int j = 0; j < n; j++) {
-                switch(lcm.arr[i][j]){
-                    case NOTUSED -> this.arr[i][j] = true;
-                    case ORR -> this.arr[i][j] = cmvArray[i] || cmvArray[j];
-                    case ANDD -> this.arr[i][j] = cmvArray[i] && cmvArray[j];
-                }
-            }
-        }
 
-
-    }
 }


### PR DESCRIPTION
This removes the constructor of the PUM class as it currently causes a merge conflict in #50. The issue is described in detail in #53.