### PR TITLE
refactor: Replace LIC 3 invalid parameter guards with assertions

### DIFF
--- a/src/main/java/se/kth/DD2480/CMV.java
+++ b/src/main/java/se/kth/DD2480/CMV.java
@@ -77,6 +77,7 @@ public class CMV {
     boolean lic3(Point[] points, int NUMPOINTS, double AREA1) {
         assert points != null : "'points' must not be null";
         assert NUMPOINTS >= 3 : "'NUMPOINTS' must be >= 3";
+        assert AREA1 >= 0 : "'AREA1' must be >= 0";
 
         for (int i = 0; i <= NUMPOINTS - 3; i++) {
             double areaOfPoints = Point.triangleArea(points[i], points[i + 1], points[i + 2]);

--- a/src/test/java/se/kth/DD2480/CMVTest.java
+++ b/src/test/java/se/kth/DD2480/CMVTest.java
@@ -147,6 +147,16 @@ class CMVTest {
     }
 
     @Test
+    void lic3_throwsError_whenArea1IsLessThanZero() {
+        CMV cmv = new CMV();
+        Point[] points = {new Point(0, 0), new Point(0, 10), new Point(10, 0)};
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            cmv.lic3(points, 3, -1.0);
+        });
+        assertEquals("'AREA1' must be >= 0", error.getMessage());
+    }
+
+    @Test
     void lic3_returnsTrue_whenFirstPointsHaveValidArea() {
         CMV cmv = new CMV();
         Point[] points = {


### PR DESCRIPTION
Replaces the handling of invalid parameters in the function `lic3` to use assert statements and updates corresponding tests to expect exceptions using `assertThrows`.