### PR TITLE
refactor: add asserts to LIC 11 (closes #83)

### DIFF
--- a/src/main/java/se/kth/DD2480/CMV.java
+++ b/src/main/java/se/kth/DD2480/CMV.java
@@ -246,9 +246,12 @@ public class CMV {
     }
 
     boolean lic11(Point[] points, int NUMPOINTS, int G_PTS) {
-        if (points == null || NUMPOINTS < 3 || G_PTS < 1 || G_PTS > NUMPOINTS - 2) {
-            return false;
-        }
+        assert points != null : "'points' must not be null";
+        assert NUMPOINTS >= 3 : "'NUMPOINTS' must be >= 3";
+        assert NUMPOINTS == points.length : "'NUMPOINTS' must equal points.length";
+        assert G_PTS >= 1 : "'G_PTS' must be >= 1";
+        assert G_PTS <= NUMPOINTS - 2 : "'G_PTS' must be <= NUMPOINTS - 2";
+
         for (int i = 0; i < NUMPOINTS - G_PTS-1; i++) {
             Point p1 = points[i];
             Point p2 = points[i + G_PTS + 1];

--- a/src/test/java/se/kth/DD2480/CMVTest.java
+++ b/src/test/java/se/kth/DD2480/CMVTest.java
@@ -1,10 +1,13 @@
 package se.kth.DD2480;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class CMVTest {
     CMV cmv;
@@ -897,7 +900,29 @@ class CMVTest {
     }
 
     @Test
-    void lic11_returnsFalseForG_PTSBeingLargerThanNUMPOINTSMinusTwo() {
+    void lic11_throwErrorWhenPointsIsNull() {
+        CMV cmv = new CMV();
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            cmv.lic11(null, 3, 1);
+        });
+        assertEquals("'points' must not be null", error.getMessage());
+    }
+
+    @Test
+    void lic11_throwErrorWhenNUMPOINTSIsLessThan3() {
+        CMV cmv = new CMV();
+        Point[] points = {
+                new Point(1, 1),
+                new Point(2, 4)
+        };
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            cmv.lic11(points, points.length, 1);
+        });
+        assertEquals("'NUMPOINTS' must be >= 3", error.getMessage());
+    }
+
+    @Test
+    void lic11_throwErrorWhenNUMPOINTSNotSameAsNumOfPoints() {
         CMV cmv = new CMV();
         Point[] points = {
                 new Point(1, 1),
@@ -906,8 +931,42 @@ class CMVTest {
                 new Point(4, 0),
                 new Point(5, 0)
         };
-        
-        assertFalse(cmv.lic11(points, points.length, 4));
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            cmv.lic11(points, 7, 1);
+        });
+        assertEquals("'NUMPOINTS' must equal points.length", error.getMessage());
+    }
+
+    @Test
+    void lic11_throwErrorWhenG_PTSIsLessThan1() {
+        CMV cmv = new CMV();
+        Point[] points = {
+                new Point(1, 1),
+                new Point(2, 4),
+                new Point(3, 3),
+                new Point(4, 0),
+                new Point(5, 0)
+        };
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            cmv.lic11(points, points.length, 0);
+        });
+        assertEquals("'G_PTS' must be >= 1", error.getMessage());
+    }
+
+    @Test
+    void lic11_throwErrorWhenG_PTSIsLargerThanNUMPOINTSMinusTwo() {
+        CMV cmv = new CMV();
+        Point[] points = {
+                new Point(1, 1),
+                new Point(2, 4),
+                new Point(3, 3),
+                new Point(4, 0),
+                new Point(5, 0)
+        };
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            cmv.lic11(points, points.length, 4);
+        });
+        assertEquals("'G_PTS' must be <= NUMPOINTS - 2", error.getMessage());
     }
 
     /**


### PR DESCRIPTION
Added asserts to LIC 11 that throws errors when the input parameters are invalid.