### PR TITLE
refactor: Update PUM class with makePUM method (Closes #96)

### DIFF
--- a/src/main/java/se/kth/DD2480/PUM.java
+++ b/src/main/java/se/kth/DD2480/PUM.java
@@ -8,20 +8,17 @@ public class PUM
     public PUM() {
         this.arr = new boolean[15][15];
     }
-    public PUM(LCM lcm, CMV cmv, Parameters p, Point[] points, int NUMPOINTS){
-        this.arr = new boolean[15][15];
-        boolean[] cmvArray = cmv.verifyAllLics(p, points , NUMPOINTS);
+
+    public boolean[][] makePUM(CONNECTORS[][] lcm, boolean[] cmvArray) {
         for(int i = 0; i < 15; ++i){
             for (int j = 0; j < 15; j++) {
-                switch(lcm.arr[i][j]){
+                switch(lcm[i][j]){
                     case NOTUSED -> this.arr[i][j] = true;
                     case ORR -> this.arr[i][j] = cmvArray[i] || cmvArray[j];
                     case ANDD -> this.arr[i][j] = cmvArray[i] && cmvArray[j];
                 }
             }
         }
-
-
+        return this.arr;
     }
-
 }


### PR DESCRIPTION
The lifecycle of the PUM class is no longer contained solely within the constructor. The constructor only initializes the array, and the makePUM method is responsible for computing the PUM array.