### PR TITLE
fix: Fixed instructsions to run script in README file (closes #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and run:
 ```java -ea se.kth.DD2480.Main```
 
 Running the above will generate the .class files within the same \src folder. To put them where they belong we can instead:  
-```javac -d ..\..\..\out se\kth\DD2480\Java.Main```  
+```javac -d ..\..\..\out se\kth\DD2480\*.java```  
 ```java -ea -cp ..\..\..\out se.kth.DD2480.Main```
 
 The -d flag ensures that the .class files end up in the specified directory, and the -cp flag tells the JVM to look for the .class files in that specified directory.


### PR DESCRIPTION
The instructions in the README.md file for running the program is incorrect. This Issue aims to fix those instructions so that they are correct.

More specifically the line `javac -d ..\..\..\out se\kth\DD2480\Java.Main` is incorrect since it should end with `Main.java` instead of `Java.Main`. But having the script end with `Main.java` only compiles the Main.class when every class needs to be compiled so it should end with `*.java` instead.