### PR TITLE
fix: Add contracts to LIC 13 tests (Closes #151)

### DIFF
--- a/src/test/java/se/kth/DD2480/CMVTest.java
+++ b/src/test/java/se/kth/DD2480/CMVTest.java
@@ -1751,7 +1751,7 @@ class CMVTest {
      *      contained within or on a circle of radius RADIUS2, and
      *    - the three data points are separated by exactly A_PTS and B_PTS
      *      consecutive intervening points, respectively, in both sets,
-     * lic13() returns false since a set of data points can be contained in a circle of RADIUS1.
+     * lic13() returns false since all set of data points can be contained in a circle of RADIUS1.
      */
     @Test
     void lic13_returnsFalse_radius1CanContain_radius2CanContain() {
@@ -1774,7 +1774,7 @@ class CMVTest {
      *      contained within or on a circle of radius RADIUS2, and
      *    - the three data points are separated by exactly A_PTS and B_PTS
      *      consecutive intervening points, respectively, in both sets,
-     * lic13() returns false since a set of data points can be contained in a circle of RADIUS1
+     * lic13() returns false since all set of data points can be contained in a circle of RADIUS1
      * and no set of data points can be contained in a circle of RADIUS2.
      */
     @Test


### PR DESCRIPTION
Includes previously missing contracts for all tests of the `lic13()` function, written as comments above each test.